### PR TITLE
Add warmup and optional timing of transfers

### DIFF
--- a/src/propagate-tor-test_cuda.cu
+++ b/src/propagate-tor-test_cuda.cu
@@ -14,6 +14,13 @@ see README.txt for instructions
 #include <chrono>
 #include <iomanip>
 
+#ifndef EXCLUDE_H2D_TRANSFER
+#define MEASURE_H2D_TRANSFER
+#endif
+#ifndef EXCLUDE_D2H_TRANSFER
+#define MEASURE_D2H_TRANSFER
+#endif
+
 #ifndef bsize
 #define bsize 1
 #endif
@@ -31,6 +38,10 @@ see README.txt for instructions
 #ifndef NITER
 #define NITER 5
 #endif
+#ifndef NWARMUP
+#define NWARMUP 2
+#endif
+
 #ifndef nlayer
 #define nlayer 20
 #endif
@@ -849,7 +860,6 @@ __global__ void GPUsequence(MPTRK* trk, MPHIT* hit, MPTRK* outtrk, const int str
 
 int main (int argc, char* argv[]) {
 
-   int itr;
    ATRK inputtrk = {
      {-12.806846618652344, -7.723824977874756, 38.13014221191406,0.23732035065189902, -2.613372802734375, 0.35594117641448975},
      {6.290299552347278e-07,4.1375109560704004e-08,7.526661534029699e-07,2.0973730840978533e-07,1.5431574240665213e-07,9.626245400795597e-08,-2.804026640189443e-06,
@@ -918,38 +928,79 @@ int main (int argc, char* argv[]) {
 
    printf("done preparing!\n");
  
-   printf("Number of struct MPTRK trk[] = %ld\n", nevts*nb);
-   printf("Number of struct MPTRK outtrk[] = %ld\n", nevts*nb);
-   printf("Number of struct struct MPHIT hit[] = %ld\n", nevts*nb);
+   printf("Number of struct MPTRK trk[] = %d\n", nevts*nb);
+   printf("Number of struct MPTRK outtrk[] = %d\n", nevts*nb);
+   printf("Number of struct struct MPHIT hit[] = %d\n", nevts*nb);
   
    printf("Size of struct MPTRK trk[] = %ld\n", nevts*nb*sizeof(struct MPTRK));
    printf("Size of struct MPTRK outtrk[] = %ld\n", nevts*nb*sizeof(struct MPTRK));
    printf("Size of struct struct MPHIT hit[] = %ld\n", nlayer*nevts*nb*sizeof(struct MPHIT));
 
-   
+   auto doWork = [&](const char* msg, int nIters) {
+     double wall_time = 0;
 
-    for (int s = 0; s<num_streams;s++){
-   transferAsyncTrk(trk_dev, trk,streams[s]);
-   transferAsyncHit(hit_dev, hit,streams[s]);
-   cudaDeviceSynchronize(); 
-   auto wall_start = std::chrono::high_resolution_clock::now();
-   for(itr=0; itr<NITER; itr++) {
-       printf("Launching ... <<<%i,%i>>>\n", (nevts*ntrks)/threadsperblock+1,threadsperblock);
-  	   GPUsequence<<<nevts*nb/threadsperblock+1,threadsperblock ,0,streams[s]>>>(trk_dev,hit_dev,outtrk_dev,s);
-   }//end of streams loop
+#ifdef MEASURE_H2D_TRANSFER
+     for(int itr=0; itr<nIters; itr++) {
+       auto wall_start = std::chrono::high_resolution_clock::now();
+       for (int s = 0; s<num_streams;s++) {
+         transferAsyncTrk(trk_dev, trk,streams[s]);
+         transferAsyncHit(hit_dev, hit,streams[s]);
+       }
 
-   cudaDeviceSynchronize(); 
-   auto wall_stop = std::chrono::high_resolution_clock::now();
-   auto wall_diff = wall_stop - wall_start;
-   auto wall_time = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(wall_diff).count()) / 1e6;
+       for (int s = 0; s<num_streams;s++) {
+         printf("%s ... <<<%i,%i>>>\n", msg, (nevts*ntrks)/threadsperblock+1,threadsperblock);
+         GPUsequence<<<nevts*nb/threadsperblock+1,threadsperblock ,0,streams[s]>>>(trk_dev,hit_dev,outtrk_dev,s);
+       }
+
+#ifdef MEASURE_D2H_TRANSFER
+       for (int s = 0; s<num_streams;s++) {
+         transfer_backAsync(outtrk, outtrk_dev,streams[s]);
+       }
+#endif // MEASURE_D2H_TRANSFER
+       cudaDeviceSynchronize();
+       auto wall_stop = std::chrono::high_resolution_clock::now();
+       wall_time += static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(wall_stop-wall_start).count()) / 1e6;
+     }
+#else // not MEASURE_H2D_TRANSFER
+     for (int s = 0; s<num_streams;s++) {
+       transferAsyncTrk(trk_dev, trk,streams[s]);
+       transferAsyncHit(hit_dev, hit,streams[s]);
+     }
+     cudaDeviceSynchronize();
+     for(int itr=0; itr<nIters; itr++) {
+       auto wall_start = std::chrono::high_resolution_clock::now();
+       for (int s = 0; s<num_streams;s++) {
+         printf("%s ... <<<%i,%i>>>\n", msg, (nevts*ntrks)/threadsperblock+1,threadsperblock);
+         GPUsequence<<<nevts*nb/threadsperblock+1,threadsperblock ,0,streams[s]>>>(trk_dev,hit_dev,outtrk_dev,s);
+       }
+
+#ifdef MEASURE_D2H_TRANSFER
+       for (int s = 0; s<num_streams;s++) {
+         transfer_backAsync(outtrk, outtrk_dev,streams[s]);
+       }
+#endif // MEASURE_D2H_TRANSFER
+       cudaDeviceSynchronize();
+       auto wall_stop = std::chrono::high_resolution_clock::now();
+       wall_time += static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(wall_stop-wall_start).count()) / 1e6;
+     }
+#endif // MEASURE_H2D_TRANSFER
+
+#ifndef MEASURE_D2H_TRANSFER
+     for (int s = 0; s<num_streams;s++) {
+       transfer_backAsync(outtrk, outtrk_dev,streams[s]);
+     }
+     cudaDeviceSynchronize();
+#endif
+
+     return wall_time;
+   };
+
+   doWork("Warming up", NWARMUP);
+   auto wall_time = doWork("Launching", NITER);
+
    printf("setup time time=%f (s)\n", (setup_stop-setup_start)*0.001);
    printf("done ntracks=%i tot time=%f (s) time/trk=%e (s)\n", nevts*ntrks*int(NITER), wall_time, wall_time/(nevts*ntrks*int(NITER)));
    printf("formatted %i %i %i %i %i %f 0 %f %i\n",int(NITER),nevts, ntrks, bsize, nb, wall_time, (setup_stop-setup_start)*0.001, nthreads);
-
-   transfer_backAsync(outtrk, outtrk_dev,streams[s]);
-   cudaDeviceSynchronize(); 
-   } //end of itr loop
-
 
 
    float avgx = 0, avgy = 0, avgz = 0, avgr = 0;

--- a/src/propagate-tor-test_cuda_v3.cu
+++ b/src/propagate-tor-test_cuda_v3.cu
@@ -14,6 +14,13 @@ see README.txt for instructions
 #include <chrono>
 #include <iomanip>
 
+#ifndef EXCLUDE_H2D_TRANSFER
+#define MEASURE_H2D_TRANSFER
+#endif
+#ifndef EXCLUDE_D2H_TRANSFER
+#define MEASURE_D2H_TRANSFER
+#endif
+
 #ifndef bsize
 #define bsize 1
 #endif
@@ -31,6 +38,10 @@ see README.txt for instructions
 #ifndef NITER
 #define NITER 5
 #endif
+#ifndef NWARMUP
+#define NWARMUP 2
+#endif
+
 #ifndef nlayer
 #define nlayer 20
 #endif
@@ -853,9 +864,7 @@ __global__ void GPUsequence(MPTRK* trk, MPHIT* hit, MPTRK* outtrk, const int str
 }
 
 int main (int argc, char* argv[]) {
-
   printf("Streams: %d, blocks: %d, threads(x,y): (%d,%d)\n",num_streams,blockspergrid,threadsperblockx,threadsperblocky);
-   int itr;
    ATRK inputtrk = {
      {-12.806846618652344, -7.723824977874756, 38.13014221191406,0.23732035065189902, -2.613372802734375, 0.35594117641448975},
      {6.290299552347278e-07,4.1375109560704004e-08,7.526661534029699e-07,2.0973730840978533e-07,1.5431574240665213e-07,9.626245400795597e-08,-2.804026640189443e-06,
@@ -926,37 +935,77 @@ int main (int argc, char* argv[]) {
 
    printf("done preparing!\n");
  
-   printf("Number of struct MPTRK trk[] = %ld\n", nevts*nb);
-   printf("Number of struct MPTRK outtrk[] = %ld\n", nevts*nb);
-   printf("Number of struct struct MPHIT hit[] = %ld\n", nevts*nb);
+   printf("Number of struct MPTRK trk[] = %d\n", nevts*nb);
+   printf("Number of struct MPTRK outtrk[] = %d\n", nevts*nb);
+   printf("Number of struct struct MPHIT hit[] = %d\n", nevts*nb);
   
    printf("Size of struct MPTRK trk[] = %ld\n", nevts*nb*sizeof(struct MPTRK));
    printf("Size of struct MPTRK outtrk[] = %ld\n", nevts*nb*sizeof(struct MPTRK));
    printf("Size of struct struct MPHIT hit[] = %ld\n", nlayer*nevts*nb*sizeof(struct MPHIT));
 
-   
+   auto doWork = [&](const char* msg, int nIters) {
+     double wall_time = 0;
 
-    for (int s = 0; s<num_streams;s++){
-   transferAsyncTrk(trk_dev, trk,streams[s]);
-   transferAsyncHit(hit_dev, hit,streams[s]);
-   cudaDeviceSynchronize(); 
-   auto wall_start = std::chrono::high_resolution_clock::now();
-   for(itr=0; itr<NITER; itr++) {
-  	   GPUsequence<<<grid,block,0,streams[s]>>>(trk_dev,hit_dev,outtrk_dev,s);
-   }//end of streams loop
+#ifdef MEASURE_H2D_TRANSFER
+     for(int itr=0; itr<nIters; itr++) {
+       auto wall_start = std::chrono::high_resolution_clock::now();
+       for (int s = 0; s<num_streams;s++) {
+         transferAsyncTrk(trk_dev, trk,streams[s]);
+         transferAsyncHit(hit_dev, hit,streams[s]);
+       }
 
-   cudaDeviceSynchronize(); 
-   auto wall_stop = std::chrono::high_resolution_clock::now();
-   auto wall_diff = wall_stop - wall_start;
-   auto wall_time = static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(wall_diff).count()) / 1e6;
+       for (int s = 0; s<num_streams;s++) {
+         GPUsequence<<<grid,block,0,streams[s]>>>(trk_dev,hit_dev,outtrk_dev,s);
+       }
+
+#ifdef MEASURE_D2H_TRANSFER
+       for (int s = 0; s<num_streams;s++) {
+         transfer_backAsync(outtrk, outtrk_dev,streams[s]);
+       }
+#endif // MEASURE_D2H_TRANSFER
+       cudaDeviceSynchronize();
+       auto wall_stop = std::chrono::high_resolution_clock::now();
+       wall_time += static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(wall_stop-wall_start).count()) / 1e6;
+     }
+#else // not MEASURE_H2D_TRANSFER
+     for (int s = 0; s<num_streams;s++) {
+       transferAsyncTrk(trk_dev, trk,streams[s]);
+       transferAsyncHit(hit_dev, hit,streams[s]);
+     }
+     cudaDeviceSynchronize();
+     for(int itr=0; itr<nIters; itr++) {
+       auto wall_start = std::chrono::high_resolution_clock::now();
+       for (int s = 0; s<num_streams;s++) {
+         GPUsequence<<<grid,block,0,streams[s]>>>(trk_dev,hit_dev,outtrk_dev,s);
+       }
+
+#ifdef MEASURE_D2H_TRANSFER
+       for (int s = 0; s<num_streams;s++) {
+         transfer_backAsync(outtrk, outtrk_dev,streams[s]);
+       }
+#endif // MEASURE_D2H_TRANSFER
+       cudaDeviceSynchronize();
+       auto wall_stop = std::chrono::high_resolution_clock::now();
+       wall_time += static_cast<double>(std::chrono::duration_cast<std::chrono::microseconds>(wall_stop-wall_start).count()) / 1e6;
+     }
+#endif // MEASURE_H2D_TRANSFER
+
+#ifndef MEASURE_D2H_TRANSFER
+     for (int s = 0; s<num_streams;s++) {
+       transfer_backAsync(outtrk, outtrk_dev,streams[s]);
+     }
+     cudaDeviceSynchronize();
+#endif
+
+     return wall_time;
+   };
+
+   doWork("Warming up", NWARMUP);
+   auto wall_time = doWork("Launching", NITER);
+
    printf("setup time time=%f (s)\n", (setup_stop-setup_start)*0.001);
    printf("done ntracks=%i tot time=%f (s) time/trk=%e (s)\n", nevts*ntrks*int(NITER), wall_time, wall_time/(nevts*ntrks*int(NITER)));
    printf("formatted %i %i %i %i %i %f 0 %f %i\n",int(NITER),nevts, ntrks, bsize, nb, wall_time, (setup_stop-setup_start)*0.001, nthreads);
-
-   transfer_backAsync(outtrk, outtrk_dev,streams[s]);
-   cudaDeviceSynchronize(); 
-   } //end of itr loop
-
 
 
    float avgx = 0, avgy = 0, avgz = 0, avgr = 0;


### PR DESCRIPTION
This PR adds
* warmup of the GPU (run the transfers and kernels a few times)
* options to include host-to-device and device-to-host transfers to the time measurements (default is to include)
* more proper loop structure for the use of CUDA streams (needs more work for proper partitioning of the work for different streams though, to be left for future PR)

~~So far done for CUDA v1 for review, after agreed I'll propagate to v2 and v3.~~ Now done for CUDA v1-v3.